### PR TITLE
Aggregated Javadoc generation in cuneiform-dist module

### DIFF
--- a/cuneiform-cmdline/pom.xml
+++ b/cuneiform-cmdline/pom.xml
@@ -37,4 +37,34 @@
 		</dependency>
 
 	</dependencies>
+	<build>
+	<plugins>
+	<plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-source-plugin</artifactId>
+		<version>2.4</version>
+		<executions>
+			<execution>
+				<id>attach-sources</id>
+				<goals>
+					<goal>jar</goal>
+				</goals>
+			</execution>
+		</executions>
+	</plugin>
+	<plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-javadoc-plugin</artifactId>
+		<version>2.10.3</version>
+		<executions>
+			<execution>
+				<id>attach-javadocs</id>
+				<goals>
+					<goal>jar</goal>
+				</goals>
+			</execution>
+		</executions>
+	</plugin>
+	</plugins>
+	</build>
 </project>

--- a/cuneiform-dist/pom.xml
+++ b/cuneiform-dist/pom.xml
@@ -93,25 +93,13 @@
 						</transformer>
 					</transformers>
 					<createDependencyReducedPom>false</createDependencyReducedPom>
+					<createSourcesJar>true</createSourcesJar>
 				</configuration>
 				<executions>
 					<execution>
 						<phase>package</phase>
 						<goals>
 							<goal>shade</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.4</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
 						</goals>
 					</execution>
 				</executions>
@@ -128,9 +116,15 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<verbose>true</verbose>
+					<includeDependencySources>true</includeDependencySources>
+					<dependencySourceIncludes>
+						<dependencySourceInclude>de.hu-berlin.wbi.cuneiform:*</dependencySourceInclude>
+					</dependencySourceIncludes>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>
-
 </project>
 

--- a/cuneiform-dist/pom.xml
+++ b/cuneiform-dist/pom.xml
@@ -117,7 +117,6 @@
 					</execution>
 				</executions>
 				<configuration>
-					<verbose>true</verbose>
 					<includeDependencySources>true</includeDependencySources>
 					<dependencySourceIncludes>
 						<dependencySourceInclude>de.hu-berlin.wbi.cuneiform:*</dependencySourceInclude>

--- a/cuneiform-dist/pom.xml
+++ b/cuneiform-dist/pom.xml
@@ -29,6 +29,14 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/scripts</directory>
+				<includes>
+					<include>log4j.properties</include>
+				</includes>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
This adds generation of javadocs for all "de.hu-berlin.wbi.cuneiform:*" artifacts in a jar (cuneiform-dist-2.0.3-RELEASE-javadoc.jar) in the cuneiform-dist project
