### PR TITLE
Add support for htcondor max_file_transfer plus two minor fixes. 

### DIFF
--- a/cuneiform-addons/cuneiform-htcondorcre/src/main/java/de/huberlin/wbi/cuneiform/htcondorcre/CondorWatcher.java
+++ b/cuneiform-addons/cuneiform-htcondorcre/src/main/java/de/huberlin/wbi/cuneiform/htcondorcre/CondorWatcher.java
@@ -1,13 +1,13 @@
 package de.huberlin.wbi.cuneiform.htcondorcre;
 
+import de.huberlin.wbi.cuneiform.core.actormodel.Actor;
+import de.huberlin.wbi.cuneiform.core.actormodel.Message;
+
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-
-import de.huberlin.wbi.cuneiform.core.actormodel.Actor;
-import de.huberlin.wbi.cuneiform.core.actormodel.Message;
 
 
 public class CondorWatcher extends Actor {
@@ -72,7 +72,7 @@ public class CondorWatcher extends Actor {
 
 	@Override
 	protected void shutdown() {
-		// nothing
+		System.exit(0);
 	}
 	
 	private int checkJobStatus(StatusMessage sm){		
@@ -113,8 +113,8 @@ public class CondorWatcher extends Actor {
 			}
 			catch( IOException e ) {
 				ex = e;
-				if( log.isWarnEnabled() ) {
-					log.warn( "Unable to start process on trial "+( trial++ )+" Waiting "+WAIT_INTERVAL+"ms: "+ex.getMessage() );
+				if( log.isWarnEnabled() && trial > 1) {
+					log.warn( "Retrying "+( ++trial )+"th time. Waiting "+WAIT_INTERVAL+"ms: "+ex.getMessage() );
 				}
 				try {
 					Thread.sleep( WAIT_INTERVAL );

--- a/cuneiform-core/src/main/java/de/huberlin/wbi/cuneiform/core/cre/LocalThread.java
+++ b/cuneiform-core/src/main/java/de/huberlin/wbi/cuneiform/core/cre/LocalThread.java
@@ -32,23 +32,6 @@
 
 package de.huberlin.wbi.cuneiform.core.cre;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.json.JSONObject;
-
 import de.huberlin.wbi.cuneiform.core.actormodel.Message;
 import de.huberlin.wbi.cuneiform.core.invoc.Invocation;
 import de.huberlin.wbi.cuneiform.core.semanticmodel.JsonReportEntry;
@@ -56,6 +39,18 @@ import de.huberlin.wbi.cuneiform.core.semanticmodel.Ticket;
 import de.huberlin.wbi.cuneiform.core.ticketsrc.TicketFailedMsg;
 import de.huberlin.wbi.cuneiform.core.ticketsrc.TicketFinishedMsg;
 import de.huberlin.wbi.cuneiform.core.ticketsrc.TicketSrcActor;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.*;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.HashSet;
+import java.util.Set;
 
 public class LocalThread implements Runnable {
 	
@@ -256,8 +251,8 @@ public class LocalThread implements Runnable {
 					catch( IOException e ) {
 						
 						ex = e;
-						if( log.isWarnEnabled() )
-							log.warn( "Unable to start process on trial "+( trial++ )+" Waiting "+WAIT_INTERVAL+"ms: "+e.getMessage() );
+						if( log.isWarnEnabled() && trial > 1) // one retry is normal, 2 is a WARN
+							log.warn( "Retrying "+ ( ++trial ) +"th time. Waiting "+WAIT_INTERVAL+"ms: "+e.getMessage() );
 						Thread.sleep( WAIT_INTERVAL );
 					}
 				} while( suc == false && trial <= MAX_TRIALS );


### PR DESCRIPTION
Please note, regarding item 1 -- we needed it for our purposes and I thought I would share in case it might be useful to everyone else.   Transferring a large number of large files during reduce stage made the job run forever.   It was much more reasonable to run a reduce job in the local universe.
This was all tested on a real condor cluster and worked well.
1. The big thing here is a new option **-m max_file_transfer** (please see cuneiform-cmdline for details of the option) This options only applicable with htcondor platform.    Htcondor has a change to not transfer more than 1G (maybe I should increase it to 100G for backwards compatibility) of input data by default or supply -m max_file_transfer.   It is not practical to transfer very huge input files and it makes sense to just run the task in the local universe where file already exists and set **universe = local** and file_transfer to "NO".    Please see details of this in CondorCreActor.   
2. htcondor job not exiting ever even after it is complete fixed. 
3  Retry warning was showing up every time when I ran my job.   I changed it to only display on 2nd and subsequent retries because it was  a little annoying.  