### PR TITLE
Fix rebar jsone dependency at tag

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,6 +7,6 @@
                  {git, "https://github.com/jcomellas/getopt.git",
                         {branch, "master"}}},
         {jsone, "1.2.3", {git, "https://github.com/sile/jsone.git",
-                               {branch, "master"}}}
+                               {tag, "1.2.3"}}}
        ]}.
 {escript_incl_apps, [getopt]}.


### PR DESCRIPTION
Apparently rebar is quite easy on version specifications.

It seems that you specify 1.2.3 for [jsone](https://github.com/sile/jsone) but it's happy cloning from master which is at version 1.2.6 

It happens that if you include cuneiform as a mix dependency in an elixir project you can't 
get away so easily with the version mismatch: 

```
Unchecked dependencies for environment test:
* jsone (https://github.com/sile/jsone.git)
  the dependency does not match the requirement ~r/1.2.3/, got "1.2.6"
** (Mix) Can't continue due to errors on dependencies
```

NOTE: consider mentioning that rebar3 can fetch packages from hex (probably needs elixir installed) 

see https://hex.pm/docs/rebar3_usage 

which won't need specifying github details

@joergen7 let's chat if you have a better solution :-) 