### PR TITLE
Adding a Cache-Found hook

### DIFF
--- a/src/cf_cre.erl
+++ b/src/cf_cre.erl
@@ -190,12 +190,17 @@ when is_tuple( App ),
 
       case maps:is_key( S, ReplyMap ) of
         false -> ok;
-        true  -> Pid ! maps:get( S, ReplyMap )
+        true  ->
+          Reply = maps:get( S, ReplyMap ),
+          Pid ! Reply,
+          case erlang:function_exported(Mod, handle_cached, 2) of
+            false -> ok;
+            true -> apply(Mod, handle_cached, [ModState, Reply])
+          end
       end,
 
       {reply, Fut, {Mod, SubscrMap1, ReplyMap, Cache, R, LibMap, ModState}}
   end;
-
 
 handle_call( get_cache, _From,
              State={_Mod, _SubscrMap, _ReplyMap, Cache, _R, _LibMap, _ModState} )


### PR DESCRIPTION
Hi @joergen7, some motivation for this: 

our custom runtime callback-module at [nextjournal.com](http://nextjournal.com) enhances cuneiform built-in `local` module 
a.o. by the ability of sending "partial reports" once each task submission gets completed.

Now since we want to send such reports even in case the runtime
is requested to submit cached results, we need a way to intercept the cached value
in the `ReplyMap`.

would be great if you could merge this, or start a discussion... 
cheers