### PR TITLE
Reverted lib_conf to initial state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,5 @@ dev:
 clean:
 	rm -rf .rebar
 	rm -rf _build
-	find doc -type f -not -name 'overview.edoc' -print0 | xargs -0 rm --
+	find doc -type f -not -name 'overview.edoc' -print0 | xargs -0 rm -f --
 	rm -f rebar.lock

--- a/src/cuneiform.erl
+++ b/src/cuneiform.erl
@@ -59,9 +59,9 @@ main( CmdLine ) ->
                   link( CrePid ),
 
                   % if remote logging is on, register the given IP address at the log manager 
-                  ok = case lists:keymember( logdb, 1, OptLst ) of
-                    false -> ok;
-                    true  ->
+                  {logdb, LogDB } = lists:keyfind( logdb, 1, OptLst ),
+                  if 
+                    LogDB /= false ->
                       {logdb, Ip} = lists:keyfind( logdb, 1, OptLst ),
                       logmgr:add_ip( Ip ),
                       {sessiondescription, SessionDescription } = lists:keyfind( sessiondescription, 1, OptLst ),
@@ -240,7 +240,7 @@ get_optspec_lst() ->
    {nthread,  $t,        "nthread",  integer,             "number of threads in local mode"},
    {platform, $p,        "platform", {atom, local},       "platform to use: local, htcondor"},
    {basedir,  $b,        "basedir",  string,              "set base directory where intermediate and output files are stored"},
-   {logdb,    $l,        "logdb",    string,              "set the IP address for the log database"},
+   {logdb,    $l,        "logdb",    {string, false},     "set the IP address for the log database"},
    {sessiondescription, $d, "session-description", {string, ""}, "a one-word description of the session to appear in the remote logging database"},
    {profiling,$r,        "profiling",{boolean, false},    "collect detailed usage statistics, requires the pegasus-kickstart binary"},
    {rlib,     undefined, "rlib",     string,              "include R library path"},

--- a/src/lib_conf.erl
+++ b/src/lib_conf.erl
@@ -21,13 +21,18 @@
 -module( lib_conf ).
 -author( "Jorgen Brandt <brandjoe@hu-berlin.de>" ).
 
+-ifdef( TEST ).
+-include_lib( "eunit/include/eunit.hrl" ).
+-endif.
+
 -export( [create_conf/3] ).
 
 %% create_conf/3
-%% @doc Creates a configuration based on a partial configuration (ManualMap)
-%% that extends upon a configuration file (ConfFile) that extends upon a
-%% default map. If there are conflicts, the order is 
-%% ManualMap > ConfFile > DefaultMap where the ManualMap has highest priority.
+%% @doc Creates a configuration map starting from a default configuration.
+%% If a configuration file (ConfFile) is found, its values override the default
+%% configuration. However, keys that are not part of the DefaultMap are discarded.
+%% In the same manner, the values of the ManualMap are incorporated into the result. 
+%% The override order is ManualMap > ConfFile > DefaultMap
 -spec create_conf( DefaultMap, ConfFile, ManualMap ) -> #{ _ => _ }
 when DefaultMap :: #{ _ => _},
      ConfFile   :: string(),
@@ -38,11 +43,12 @@ when is_map( DefaultMap ),
      is_list( ConfFile ),
      is_map( ManualMap ) ->
 
-  % try to read the configuration file
-  Default = case file:read_file( ConfFile ) of
-      % if it can't be loaded, use the default map as merger
+  % merge default map and configuration file
+  Merge = case file:read_file( ConfFile ) of
+      % configuration file is allowed to miss, use default map
       {error, enoent}  -> DefaultMap;
       {error, Reason1} -> error( {Reason1, ConfFile} );
+      % if found, load and override settings DefaultMap 
       {ok, B}          ->
         S = binary_to_list( B ),
         {ok, Tokens, _} = erl_scan:string( S ),
@@ -50,11 +56,28 @@ when is_map( DefaultMap ),
           {error, Reason2} -> error( Reason2 );
           {ok, Y}         -> Y
         end,
-        % override (and extend) the default map with what is 
-        % specified in the configuration file
-        maps:merge( DefaultMap, ConfMap )
+        % for each key in the default map, look up the value in the ConfMap and use it instead
+        % the lookup of key nthread in ConfMap doesn't cause an error, since V is default
+        maps:map( fun( K, V ) -> maps:get( K, ConfMap, V ) end, DefaultMap )
     end,
+  % for each key in the Merge map, look up the value in the ManualMap and use it instead
+  maps:map( fun( K, V ) -> maps:get( K, ManualMap, V ) end, Merge ).
 
-  % override (and extend) the merged default map and configuration file
-  % with what is specified in the manual map.
-  maps:merge( Default, ManualMap ).
+%% =============================================================================
+%% Unit Tests
+%% =============================================================================
+
+-ifdef( TEST ).
+
+simple_create_conf_test_() ->
+
+  DefaultMap = #{ nthread => 1, profiling => false },
+  % keys in the manual map that do not appear in the default map are discarded
+  ManualMap = #{ nthread => 4, some_nonsense => whacko },
+  Expected = #{ profiling => false, nthread => 4 },
+  
+  Conf = create_conf( DefaultMap, "", ManualMap),
+
+  ?_assert( Conf == Expected ).
+
+-endif.

--- a/src/local.erl
+++ b/src/local.erl
@@ -44,7 +44,8 @@
 
 -define( DEFAULT_CONF, #{ basedir => "/tmp/cf",
                           nthread => case erlang:system_info( logical_processors_available ) of unknown -> 1; N -> N end,
-                          profiling => false } ).
+                          profiling => false,
+                          logdb => false } ).
 -define( CONF_FILE, "/usr/local/etc/cuneiform/local.conf" ).
 
 %% =============================================================================
@@ -69,7 +70,7 @@ init( ManualMap ) when is_map( ManualMap ) ->
   {ok, QueueRef} = gen_queue:start_link( NSlot ),
   
   % show a summary of the configuration
-  Logging = maps:get( logdb, Conf, false ),
+  Logging = maps:get( logdb, Conf ),
   Profiling = maps:get( profiling, Conf ), 
   error_logger:info_msg( io_lib:format( "Base directory      ~s~nNumber of threads   ~p~nRemote Logging      ~s~nProfiling           ~p~n", [BaseDir, NSlot, Logging, Profiling] ) ),
 

--- a/src/logmgr.erl
+++ b/src/logmgr.erl
@@ -80,7 +80,7 @@ handle_event( LogEntry, State = #mod_state{ ip_lst = IpLst, session = Session } 
     Url = lists:flatten( io_lib:format( "http://~s:~p/~s", [Ip, ?PORT, ?PATH] ) ),
     Request = {Url, [], "application/json", to_json( LogEntry, Session )},
 
-    X = httpc:request( post, Request, [], [{sync, true}] )
+    httpc:request( post, Request, [], [{sync, true}] )
 
    end,
 


### PR DESCRIPTION
Keys that are not in the most default map are discarded from the
configuration file and manual map.
Default for the logdb parameter is now the atom false.